### PR TITLE
Спрятал SECRET_KEY в переменную окружения

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
             - run:
                 name: run tests
                 command: |
+                  echo "export SECRET_KEY='not_secret'" > .env
                   mkdir test-results
                   mkdir test-reports
                   pipenv run flake8 --statistics

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,15 @@
 repos:
-
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
     -   id: check-ast
-    -   id: fix-encoding-pragma
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
+        always_run: true
     -   id: flake8
-    -   id: check-yaml
-    -   id: check-added-large-files
+        always_run: true
     -   id: detect-private-key
+        always_run: true
     -   id: check-merge-conflict
+        always_run: true
 
 -   repo: https://github.com/PyCQA/bandit
     rev: 1.6.2

--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,5 @@ pytest = "*"
 pytest-cov = "*"
 
 [packages]
+python-dotenv = "*"
 django = "*"
-
-[requires]
-python_version = "3.7"

--- a/webtoe/settings.py
+++ b/webtoe/settings.py
@@ -11,6 +11,9 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
 import os
+from dotenv import load_dotenv
+
+load_dotenv(verbose=True)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -20,7 +23,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'r73+1bm!k7-3qyatp*2lhie%7r3l1om_e9jng^f^fcy52)5s@&'
+SECRET_KEY = os.getenv('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
- Создание локального файла с переменной ```SECRET_KEY``` на сервере **CircleCI**
- Убраны ненужные хуки из **pre-commit** конфига
- Убрана обязательная версия **Python** из ```Pipfile```, т.к. локальная версия на моем компьютере не совпадает с версией на **CircleCI**
- Добавлен пакет ```python-dotenv``` для более удобной работы с переменными окружения
- Вместо явно указанного ключа, используется функция ```load_dotenv(verbose=True)``` и ```os.getenv('SECRET_KEY')```